### PR TITLE
Use SQLite with in-memory database for test suite.

### DIFF
--- a/delete_in_batches.gemspec
+++ b/delete_in_batches.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
-  spec.add_development_dependency "pg"
+  spec.add_development_dependency "sqlite3"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,7 +12,7 @@ ActiveRecord::Base.default_timezone = :utc
 ActiveRecord::Base.time_zone_aware_attributes = true
 
 # migrations
-ActiveRecord::Base.establish_connection adapter: "postgresql", database: "delete_in_batches_test"
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
 
 ActiveRecord::Migration.create_table :tweets, force: true do |t|
   t.integer :user_id


### PR DESCRIPTION
SQLite with in-momory database doesn't need any configuration like we
need for PostgreSQL and MySQL. Don't need to create database manually
before running the tests.

In-Memory database ceases to exist as soon as the database connection
is closed.
